### PR TITLE
fix long message causing program exit at exception.

### DIFF
--- a/src/rosconsole/rosconsole.cpp
+++ b/src/rosconsole/rosconsole.cpp
@@ -437,27 +437,14 @@ void initialize()
 
 void vformatToBuffer(boost::shared_array<char>& buffer, size_t& buffer_size, const char* fmt, va_list args)
 {
-#ifdef _MSC_VER
-  va_list arg_copy = args; // dangerous?
-#else
   va_list arg_copy;
   va_copy(arg_copy, args);
-#endif
-#ifdef _MSC_VER
-  size_t total = vsnprintf_s(buffer.get(), buffer_size, buffer_size, fmt, args);
-#else
   size_t total = vsnprintf(buffer.get(), buffer_size, fmt, args);
-#endif
   if (total >= buffer_size)
   {
     buffer_size = total + 1;
     buffer.reset(new char[buffer_size]);
-
-#ifdef _MSC_VER
-    vsnprintf_s(buffer.get(), buffer_size, buffer_size, fmt, arg_copy);
-#else
     vsnprintf(buffer.get(), buffer_size, fmt, arg_copy);
-#endif
   }
   va_end(arg_copy);
 }


### PR DESCRIPTION
Remove the vsnprintf_s usage which has a effect when the buffer is not sufficient enough, it throws invalid parameter exception, and in turn, it terminates the program which loads the rosconsole.dll if the host executable doesn't define its owned `_set_invalid_parameter_handler`.

Plus, remove `va_list arg_copy = args` and use `va_copy` instead.